### PR TITLE
fix(installation): fix 403 error during install

### DIFF
--- a/increase_swap_addon/CHANGELOG.md
+++ b/increase_swap_addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.4.1] - 2026-04-22
+
+### Fixed
+- Restore addon installation: v1.4.0 referenced `ghcr.io/hassio-addons/app-base`, which is not anonymously pullable from ghcr.io (returns 403 on the token endpoint).
+- Pin base image to `ghcr.io/hassio-addons/base:20.1.0` (latest stable, publicly pullable).
+
 ## [1.4.0] - 2026-04-06
 
 ### Changed

--- a/increase_swap_addon/Dockerfile
+++ b/increase_swap_addon/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/app-base:v20.0.2
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.0
 FROM ${BUILD_FROM}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/increase_swap_addon/config.yaml
+++ b/increase_swap_addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Increase Swap"
-version: "1.4.0"
+version: "1.4.1"
 slug: increase_swap_addon
 description: "This add-on increases the swap space on your system."
 url: "https://github.com/TazzerMAN/increase_swap_addon"


### PR DESCRIPTION
- Bump version to 1.4.1
- Fix addon installation issues by updating base image reference
- fix #19 